### PR TITLE
Fix issues with credentials in module settings form

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -101,10 +101,10 @@ class assign_submission_maharaws extends assign_submission_plugin {
             array('maxlength' => 255, 'size' => 50)
         );
         $mform->setType('assignsubmission_maharaws_url', PARAM_URL);
-        if (!empty(get_config('assignsubmission_maharaws', 'url'))) {
-            $mform->setDefault('assignsubmission_maharaws_url', get_config('assignsubmission_maharaws', 'url'));
-        } else if (!empty($this->get_config('url'))) {
+        if (!empty($this->get_config('url'))) {
             $mform->setDefault('assignsubmission_maharaws_url', $this->get_config('url'));
+        } else if (!empty(get_config('assignsubmission_maharaws', 'url'))) {
+            $mform->setDefault('assignsubmission_maharaws_url', get_config('assignsubmission_maharaws', 'url'));
         }
 
         $mform->addHelpButton('assignsubmission_maharaws_url', 'url', 'assignsubmission_maharaws');
@@ -122,10 +122,10 @@ class assign_submission_maharaws extends assign_submission_plugin {
                 array('maxlength' => 255, 'size' => 50)
             );
             $mform->setType('assignsubmission_maharaws_key', PARAM_ALPHANUM);
-            if (!empty(get_config('assignsubmission_maharaws', 'key'))) {
-                $mform->setDefault('assignsubmission_maharaws_key', get_config('assignsubmission_maharaws', 'key'));
-            } else if (!empty($this->get_config('key'))) {
+            if (!empty($this->get_config('key'))) {
                 $mform->setDefault('assignsubmission_maharaws_key', $this->get_config('key'));
+            } else if (!empty(get_config('assignsubmission_maharaws', 'key'))) {
+                $mform->setDefault('assignsubmission_maharaws_key', get_config('assignsubmission_maharaws', 'key'));
             }
             $mform->addHelpButton('assignsubmission_maharaws_key', 'key', 'assignsubmission_maharaws');
             $mform->hideIf('assignsubmission_maharaws_key', 'assignsubmission_maharaws_enabled', 'notchecked');
@@ -140,10 +140,10 @@ class assign_submission_maharaws extends assign_submission_plugin {
                 array('maxlength' => 255, 'size' => 50)
             );
             $mform->setType('assignsubmission_maharaws_secret', PARAM_ALPHANUM);
-            if (!empty(get_config('assignsubmission_maharaws', 'secret'))) {
-                $mform->setDefault('assignsubmission_maharaws_secret', get_config('assignsubmission_maharaws', 'secret'));
-            } else if (!empty($this->get_config('secret'))) {
+            if (!empty($this->get_config('secret'))) {
                 $mform->setDefault('assignsubmission_maharaws_secret', $this->get_config('secret'));
+            } else if (!empty(get_config('assignsubmission_maharaws', 'secret'))) {
+                $mform->setDefault('assignsubmission_maharaws_secret', get_config('assignsubmission_maharaws', 'secret'));
             }
 
             $mform->addHelpButton('assignsubmission_maharaws_secret', 'secret', 'assignsubmission_maharaws');

--- a/locallib.php
+++ b/locallib.php
@@ -211,16 +211,24 @@ class assign_submission_maharaws extends assign_submission_plugin {
             if ($data->assignsubmission_maharaws_lockpages == ASSIGNSUBMISSION_MAHARAWS_SETTING_DONTLOCK) {
                 $data->assignsubmission_maharaws_archiveonrelease = 0;
             }
-
-            $this->set_config('url', $data->assignsubmission_maharaws_url);
             $this->set_config('key', $data->assignsubmission_maharaws_key);
             $this->set_config('secret', $data->assignsubmission_maharaws_secret);
-            $this->set_config('debug', false);
-            $this->set_config('remoteuser', false);
             $this->set_config('lock', $data->assignsubmission_maharaws_lockpages);
-            $this->set_config('username_attribute', 'email');
             $this->set_config('archiveonrelease', $data->assignsubmission_maharaws_archiveonrelease);
+        } else {
+            if (get_config('assignsubmission_maharaws', 'lock') == ASSIGNSUBMISSION_MAHARAWS_SETTING_DONTLOCK) {
+                $data->assignsubmission_maharaws_archiveonrelease = 0;
+            }
+            $this->set_config('key', get_config('assignsubmission_maharaws', 'key'));
+            $this->set_config('secret', get_config('assignsubmission_maharaws', 'secret'));
+            $this->set_config('lock', get_config('assignsubmission_maharaws', 'lock'));
         }
+
+        $this->set_config('url', $data->assignsubmission_maharaws_url);
+        $this->set_config('archiveonrelease', $data->assignsubmission_maharaws_archiveonrelease);
+        $this->set_config('debug', false);
+        $this->set_config('remoteuser', false);
+        $this->set_config('username_attribute', 'email');
 
         // Test Mahara connection.
         try {


### PR DESCRIPTION
This PR addresses two issues:

- #50 : following #7 when a user without the assignsubmission/maharaws:configure capability, submitting the form would break because the default credentials were not retrieved before the test of the Mahara connection. The change I've implemented will retrieve them, whether global credentials are forced or not. This is because currently a user without the capability can't enter credentials even when global credentials are not forced.

- while investigating the above, it also appeared that upon editing a module, the credentials retrieved to populate the form would be the default ones instead of those saved when the module was created. I switch the checks to reverse this logic.
