### PR TITLE
WR438262: Submission interface improvements

### DIFF
--- a/lang/en/assignsubmission_maharaws.php
+++ b/lang/en/assignsubmission_maharaws.php
@@ -25,6 +25,7 @@
 $string['assign_submission_maharaws_name'] = 'Mahara Assignment submission (web services)';
 $string['assign_submission_maharaws_description'] = 'Mahara functions used in Mahara assignment submission plugin.<br />Publishing this service on a Moodle site has no effect. Subscribe to this service if you want to be able to use assignments with {$a}.<br />';
 $string['collectionsby'] = 'Collections by {$a}';
+$string['currentsubmitted'] = 'Current submitted {$a}';
 $string['debug_help'] = 'Debug option to interupt the OAuth SSO login jump so parameters can be inspected';
 $string['debug'] = 'Debug OAuth';
 $string['defaultlockpages_help'] = 'Default setting to use for the "{$a}" setting in new Mahara assignments.';

--- a/locallib.php
+++ b/locallib.php
@@ -477,9 +477,20 @@ class assign_submission_maharaws extends assign_submission_plugin {
                 );
 
                 foreach ($views['data'] as $view) {
-                    $viewurl = "/view/view.php?id=" . $view['id'];
-                    $anchor = $this->get_preview_url($view['title'], $viewurl, strip_tags($view['description']));
-                    $mform->addElement('radio', 'viewid', '', $anchor, 'v' . $view['id']);
+                    // If the view (page) hasn't already been submitted, add it to the options for selection.
+                    if ($view['submissionoriginal'] == 0) {
+                        $viewurl = "/view/view.php?id=" . $view['id'];
+                        $anchor = $this->get_preview_url($view['title'], $viewurl, strip_tags($view['description']));
+                        $mform->addElement('radio', 'viewid', '', $anchor, 'v' . $view['id']);
+                    }
+                    if ($maharasubmission && $view['id'] == $maharasubmission->viewid) {
+                        $currentpagesubmitted = $mform->createElement('static', 'currentsubmission',
+                            get_string('currentsubmitted', 'assignsubmission_maharaws', 'page'), $view['displaytitle']);
+                    }
+                }
+
+                if (!empty($currentpagesubmitted)) {
+                    $mform->addElement($currentpagesubmitted);
                 }
             }
             if (!empty($views['collections']['data'])) {
@@ -487,9 +498,21 @@ class assign_submission_maharaws extends assign_submission_plugin {
                     get_string('collectionsby', 'assignsubmission_maharaws', $views['displayname'])
                 );
                 foreach ($views['collections']['data'] as $coll) {
-                    $anchor = $this->get_preview_url($coll['name'], $coll['url'], strip_tags($coll['description']));
-                    $mform->addElement('radio', 'viewid', '', $anchor, 'c' . $coll['id']);
+                    // If the collection hasn't already been submitted, add it to the options for selection.
+                    if ($coll['submissionoriginal'] == 0) {
+                        $anchor = $this->get_preview_url($coll['name'], $coll['url'], strip_tags($coll['description']));
+                        $mform->addElement('radio', 'viewid', '', $anchor, 'c' . $coll['id']);
+                    }
+
+                    if ($maharasubmission && $coll['id'] == $maharasubmission->viewid) {
+                        $currentcollsubmitted = $mform->createElement('static', 'currentsubmission',
+                           get_string('currentsubmitted', 'assignsubmission_maharaws', 'collection'), $coll['name']);
+                    }
                 }
+                if (!empty($currentcollsubmitted)) {
+                    $mform->addElement($currentcollsubmitted);
+                }
+
             }
             if (!empty($maharasubmission)) {
                 if ($maharasubmission->iscollection) {

--- a/version.php
+++ b/version.php
@@ -25,8 +25,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2023110900;
-$plugin->release   = 2023110900;
+$plugin->version   = 2024091300;
+$plugin->release   = 2024091300;
 $plugin->requires  = 2020061500;
 $plugin->component = 'assignsubmission_maharaws';
 $plugin->supported = [39, 403];  // Available as of Moodle 3.9.0 or later.


### PR DESCRIPTION
Addresses #83 

However, once the locked options are removed from the selection screen it makes it difficult for the student to see what's currently submitted as that is also locked,  so I've added in a static element to display the currently selected item.

Previously the currently selected item would have been selected, but if the student tries to resubmit it instead of going back/canceling, an error occurs, so this also addresses that.

### Submitted page
![Screenshot from 2024-09-03 12-46-16](https://github.com/user-attachments/assets/e0cc9bf7-5d94-4ac0-9859-60250628460e)



### Submitted collection

![Screenshot from 2024-09-03 12-38-49](https://github.com/user-attachments/assets/5c9e9502-945f-447a-ab43-fb3d447a9b20)


